### PR TITLE
Add functions for rollback to commit without bumping version

### DIFF
--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1441,3 +1441,42 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *te
 		})
 	})
 }
+
+func TestSaveCurrentVersion(t *testing.T) {
+	tree := setupMutableTree(t)
+	tree.SetInitialVersion(9)
+
+	tree.Set([]byte("a"), []byte{0x01})
+	_, version, err := tree.SaveVersion()
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, version)
+	_, version, err = tree.SaveCurrentVersion()
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, version)
+}
+
+func TestSaveCurrentVersion_BadVersion(t *testing.T) {
+	tree := setupMutableTree(t)
+	tree.SetInitialVersion(9)
+
+	tree.Set([]byte("a"), []byte{0x01})
+	_, version, err := tree.SaveVersion()
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, version)
+	tree.version = 10
+	_, version, err = tree.SaveCurrentVersion()
+	require.Error(t, err)
+}
+
+func TestSaveCurrentVersion_ChangedHash(t *testing.T) {
+	tree := setupMutableTree(t)
+	tree.SetInitialVersion(9)
+
+	tree.Set([]byte("a"), []byte{0x01})
+	_, version, err := tree.SaveVersion()
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, version)
+	tree.Set([]byte("b"), []byte{0x02})
+	_, version, err = tree.SaveCurrentVersion()
+	require.Error(t, err)
+}

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1466,6 +1466,7 @@ func TestSaveCurrentVersion_BadVersion(t *testing.T) {
 	tree.version = 10
 	_, version, err = tree.SaveCurrentVersion()
 	require.Error(t, err)
+	assert.EqualValues(t, 10, version)
 }
 
 func TestSaveCurrentVersion_ChangedHash(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
Added a `SaveCurrentVersion` function for the use case where one needs to commit the current version without any change to data or version bump (e.g. rollback)

## Testing performed to validate your change
unit tests
