### PR TITLE
Fast fail & log if there are unexpected concurrent access to MutableTree

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -135,10 +135,13 @@ func (tree *MutableTree) prepareOrphansSlice() []*Node {
 func (tree *MutableTree) Set(key, value []byte) (updated bool, err error) {
 	if !tree.entryMtx.TryLock() {
 		fmt.Println(string(tree.entryStack))
-		panic("TONYTEST: error acquiring lock on iavl Set")
+		panic("IAVL-MT: error acquiring lock on iavl Set")
 	}
 	tree.entryStack = debug.Stack()
-	defer tree.entryMtx.Unlock()
+	defer func() {
+		tree.entryStack = []byte{}
+		tree.entryMtx.Unlock()
+	}()
 	var orphaned []*Node
 	orphaned, updated, err = tree.set(key, value)
 	if err != nil {
@@ -156,7 +159,7 @@ func (tree *MutableTree) Set(key, value []byte) (updated bool, err error) {
 func (tree *MutableTree) Get(key []byte) ([]byte, error) {
 	if !tree.entryMtx.TryRLock() {
 		fmt.Println(string(tree.entryStack))
-		panic("TONYTEST: error acquiring lock on iavl Get")
+		panic("IAVL-MT: error acquiring lock on iavl Get")
 	}
 	defer tree.entryMtx.RUnlock()
 
@@ -194,7 +197,7 @@ func (tree *MutableTree) Import(version int64) (*Importer, error) {
 func (tree *MutableTree) Iterate(fn func(key []byte, value []byte) bool) (stopped bool, err error) {
 	if !tree.entryMtx.TryRLock() {
 		fmt.Println(string(tree.entryStack))
-		panic("TONYTEST: error acquiring lock on iavl Iterate")
+		panic("IAVL-MT: error acquiring lock on iavl Iterate")
 	}
 	defer tree.entryMtx.RUnlock()
 
@@ -229,7 +232,7 @@ func (tree *MutableTree) Iterate(fn func(key []byte, value []byte) bool) (stoppe
 func (tree *MutableTree) Iterator(start, end []byte, ascending bool) (dbm.Iterator, error) {
 	if !tree.entryMtx.TryRLock() {
 		fmt.Println(string(tree.entryStack))
-		panic("TONYTEST: error acquiring lock on iavl Iterator")
+		panic("IAVL-MT: error acquiring lock on iavl Iterator")
 	}
 	defer tree.entryMtx.RUnlock()
 
@@ -348,10 +351,13 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte, orph
 func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
 	if !tree.entryMtx.TryLock() {
 		fmt.Println(string(tree.entryStack))
-		panic("TONYTEST: error acquiring lock on iavl Remove")
+		panic("IAVL-MT: error acquiring lock on iavl Remove")
 	}
 	tree.entryStack = debug.Stack()
-	defer tree.entryMtx.Unlock()
+	defer func() {
+		tree.entryStack = []byte{}
+		tree.entryMtx.Unlock()
+	}()
 
 	val, orphaned, removed, err := tree.remove(key)
 	if err != nil {
@@ -503,10 +509,13 @@ func (tree *MutableTree) Load() (int64, error) {
 func (tree *MutableTree) LazyLoadVersion(targetVersion int64) (int64, error) {
 	if !tree.entryMtx.TryLock() {
 		fmt.Println(string(tree.entryStack))
-		panic("TONYTEST: error acquiring lock on iavl LazyLoadVersion")
+		panic("IAVL-MT: error acquiring lock on iavl LazyLoadVersion")
 	}
 	tree.entryStack = debug.Stack()
-	defer tree.entryMtx.Unlock()
+	defer func() {
+		tree.entryStack = []byte{}
+		tree.entryMtx.Unlock()
+	}()
 	latestVersion, err := tree.ndb.getLatestVersion()
 	if err != nil {
 		return 0, err
@@ -579,10 +588,13 @@ func (tree *MutableTree) LazyLoadVersion(targetVersion int64) (int64, error) {
 func (tree *MutableTree) LoadVersion(targetVersion int64) (int64, error) {
 	if !tree.entryMtx.TryLock() {
 		fmt.Println(string(tree.entryStack))
-		panic("TONYTEST: error acquiring lock on iavl LoadVersion")
+		panic("IAVL-MT: error acquiring lock on iavl LoadVersion")
 	}
 	tree.entryStack = debug.Stack()
-	defer tree.entryMtx.Unlock()
+	defer func() {
+		tree.entryStack = []byte{}
+		tree.entryMtx.Unlock()
+	}()
 
 	roots, err := tree.ndb.getRoots()
 	if err != nil {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -134,7 +134,8 @@ func (tree *MutableTree) prepareOrphansSlice() []*Node {
 // updated, while false means it was a new key.
 func (tree *MutableTree) Set(key, value []byte) (updated bool, err error) {
 	if !tree.entryMtx.TryLock() {
-		fmt.Println(string(tree.entryStack))
+		fmt.Printf("Competing goroutine: %s\n", string(tree.entryStack))
+		fmt.Printf("Current goroutine: %s\n", string(debug.Stack()))
 		panic("IAVL-MT: error acquiring lock on iavl Set")
 	}
 	tree.entryStack = debug.Stack()
@@ -158,7 +159,8 @@ func (tree *MutableTree) Set(key, value []byte) (updated bool, err error) {
 // The returned value must not be modified, since it may point to data stored within IAVL.
 func (tree *MutableTree) Get(key []byte) ([]byte, error) {
 	if !tree.entryMtx.TryRLock() {
-		fmt.Println(string(tree.entryStack))
+		fmt.Printf("Competing goroutine: %s\n", string(tree.entryStack))
+		fmt.Printf("Current goroutine: %s\n", string(debug.Stack()))
 		panic("IAVL-MT: error acquiring lock on iavl Get")
 	}
 	defer tree.entryMtx.RUnlock()
@@ -196,7 +198,8 @@ func (tree *MutableTree) Import(version int64) (*Importer, error) {
 // since they may point to data stored within IAVL. Returns true if stopped by callnack, false otherwise
 func (tree *MutableTree) Iterate(fn func(key []byte, value []byte) bool) (stopped bool, err error) {
 	if !tree.entryMtx.TryRLock() {
-		fmt.Println(string(tree.entryStack))
+		fmt.Printf("Competing goroutine: %s\n", string(tree.entryStack))
+		fmt.Printf("Current goroutine: %s\n", string(debug.Stack()))
 		panic("IAVL-MT: error acquiring lock on iavl Iterate")
 	}
 	defer tree.entryMtx.RUnlock()
@@ -231,7 +234,8 @@ func (tree *MutableTree) Iterate(fn func(key []byte, value []byte) bool) (stoppe
 // CONTRACT: no updates are made to the tree while an iterator is active.
 func (tree *MutableTree) Iterator(start, end []byte, ascending bool) (dbm.Iterator, error) {
 	if !tree.entryMtx.TryRLock() {
-		fmt.Println(string(tree.entryStack))
+		fmt.Printf("Competing goroutine: %s\n", string(tree.entryStack))
+		fmt.Printf("Current goroutine: %s\n", string(debug.Stack()))
 		panic("IAVL-MT: error acquiring lock on iavl Iterator")
 	}
 	defer tree.entryMtx.RUnlock()
@@ -350,7 +354,8 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte, orph
 // after this call, since it may point to data stored inside IAVL.
 func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
 	if !tree.entryMtx.TryLock() {
-		fmt.Println(string(tree.entryStack))
+		fmt.Printf("Competing goroutine: %s\n", string(tree.entryStack))
+		fmt.Printf("Current goroutine: %s\n", string(debug.Stack()))
 		panic("IAVL-MT: error acquiring lock on iavl Remove")
 	}
 	tree.entryStack = debug.Stack()
@@ -508,7 +513,8 @@ func (tree *MutableTree) Load() (int64, error) {
 // returned.
 func (tree *MutableTree) LazyLoadVersion(targetVersion int64) (int64, error) {
 	if !tree.entryMtx.TryLock() {
-		fmt.Println(string(tree.entryStack))
+		fmt.Printf("Competing goroutine: %s\n", string(tree.entryStack))
+		fmt.Printf("Current goroutine: %s\n", string(debug.Stack()))
 		panic("IAVL-MT: error acquiring lock on iavl LazyLoadVersion")
 	}
 	tree.entryStack = debug.Stack()
@@ -587,7 +593,8 @@ func (tree *MutableTree) LazyLoadVersion(targetVersion int64) (int64, error) {
 // Returns the version number of the latest version found
 func (tree *MutableTree) LoadVersion(targetVersion int64) (int64, error) {
 	if !tree.entryMtx.TryLock() {
-		fmt.Println(string(tree.entryStack))
+		fmt.Printf("Competing goroutine: %s\n", string(tree.entryStack))
+		fmt.Printf("Current goroutine: %s\n", string(debug.Stack()))
 		panic("IAVL-MT: error acquiring lock on iavl LoadVersion")
 	}
 	tree.entryStack = debug.Stack()

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -130,6 +130,10 @@ func (tree *MutableTree) prepareOrphansSlice() []*Node {
 // to slices stored within IAVL. It returns true when an existing value was
 // updated, while false means it was a new key.
 func (tree *MutableTree) Set(key, value []byte) (updated bool, err error) {
+	if !tree.mtx.TryLock() {
+		panic("TONYTEST: error acquiring lock on iavl Remove")
+	}
+	defer tree.mtx.Unlock()
 	var orphaned []*Node
 	orphaned, updated, err = tree.set(key, value)
 	if err != nil {
@@ -319,6 +323,11 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte, orph
 // Remove removes a key from the working tree. The given key byte slice should not be modified
 // after this call, since it may point to data stored inside IAVL.
 func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
+	if !tree.mtx.TryLock() {
+		panic("TONYTEST: error acquiring lock on iavl Remove")
+	}
+	defer tree.mtx.Unlock()
+
 	val, orphaned, removed, err := tree.remove(key)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
## Describe your changes and provide context
Mutable trees are expected to be called in a thread-safe manner: either one write & 0 read, or 0 write & N reads. This PR uses TryLock/TryRLock to enforce this expectation. It also prints the stack trace of the competing goroutine (caveat: if a write fails to TryLock because of a competing read goroutine, no stack trace will be printed, because setting stack trace in the read goroutine itself is subject to race condition since there can be multiple read goroutines running concurrently)

## Testing performed to validate your change
logs
