### PR TITLE
Remove deadlock from DeleteVersions

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -1069,8 +1069,6 @@ func (tree *MutableTree) SetInitialVersion(version uint64) {
 // DeleteVersions deletes a series of versions from the MutableTree.
 // Deprecated: please use DeleteVersionsRange instead.
 func (tree *MutableTree) DeleteVersions(versions ...int64) error {
-	tree.mtx.Lock()
-	defer tree.mtx.Unlock()
 
 	logger.Debug("DELETING VERSIONS: %v\n", versions)
 


### PR DESCRIPTION
## Describe your changes and provide context
DeleteVersions() calls DeleteVersionsRange() which both acqurie deadlock, resulting i n the following deadlock:
```

goroutine 1 [semacquire]:
sync.runtime_SemacquireMutex(0xc03e30fb10?, 0x76?, 0xc?)
	/usr/local/go/src/runtime/sema.go:77 +0x25
sync.(*Mutex).lockSlow(0xc000527f30)
	/usr/local/go/src/sync/mutex.go:171 +0x165
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:90
github.com/cosmos/iavl.(*MutableTree).DeleteVersionsRange(0xc0021810e0, 0x3518bd, 0x3523aa)
	/root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.1/mutable_tree.go:1108 +0x66
github.com/cosmos/iavl.(*MutableTree).DeleteVersions(0xc0021810e0, {0xc046436000?, 0xaed, 0xc00})
	/root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.1/mutable_tree.go:1096 +0x38a
```
## Testing performed to validate your change
Will perform upgrade
