### PR TITLE
Fix mutable tree race condition

### DIFF
--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -3,7 +3,6 @@ package iavl
 import (
 	"fmt"
 	"strings"
-	"sync"
 
 	dbm "github.com/tendermint/tm-db"
 )
@@ -19,7 +18,6 @@ type ImmutableTree struct {
 	ndb                    *nodeDB
 	version                int64
 	skipFastStorageUpgrade bool
-	mtx                    *sync.Mutex
 }
 
 // NewImmutableTree creates both in-memory and persistent instances
@@ -32,7 +30,6 @@ func NewImmutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool) *Im
 		// NodeDB-backed Tree.
 		ndb:                    newNodeDB(db, cacheSize, nil),
 		skipFastStorageUpgrade: skipFastStorageUpgrade,
-		mtx:                    &sync.Mutex{},
 	}
 }
 
@@ -42,7 +39,6 @@ func NewImmutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastS
 		// NodeDB-backed Tree.
 		ndb:                    newNodeDB(db, cacheSize, opts),
 		skipFastStorageUpgrade: skipFastStorageUpgrade,
-		mtx:                    &sync.Mutex{},
 	}
 }
 
@@ -322,7 +318,6 @@ func (t *ImmutableTree) clone() *ImmutableTree {
 		ndb:                    t.ndb,
 		version:                t.version,
 		skipFastStorageUpgrade: t.skipFastStorageUpgrade,
-		mtx:                    t.mtx,
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Setting `mtx` on ImmutableTree level can cause race condition like the following:
```
Write at 0x00c000315db0 by goroutine 330:
  github.com/cosmos/iavl.(*MutableTree).SaveVersion()
      /Users/cyson/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.2-tony-3/mutable_tree.go:931 +0xf47

Previous read at 0x00c000315db0 by goroutine 420:
  github.com/cosmos/iavl.(*MutableTree).VersionExists()
      /Users/cyson/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.2-tony-3/mutable_tree.go:75 +0x58
```
because the `ImmutableTree` field of mutable tree can get modified when some other thread is trying to get the old ImmutableTree's mutex. Since we no longer lock during iterator iteration, there is no need to have the mutex on ImmutableTree level and thus we promote it to the mutable tree level

## Testing performed to validate your change
WIP

