### PR TITLE
Skip orphan metadata if versioning is not needed

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -1070,6 +1070,13 @@ func (tree *MutableTree) SetInitialVersion(version uint64) {
 func (tree *MutableTree) DeleteVersions(versions ...int64) error {
 	logger.Debug("DELETING VERSIONS: %v\n", versions)
 
+	if tree.ndb.ShouldNotUseVersion() {
+		// no need to delete versions since there is no version to be
+		// deleted except the current one, which shouldn't be deleted
+		// in any circumstance
+		return nil
+	}
+
 	if len(versions) == 0 {
 		return nil
 	}

--- a/options.go
+++ b/options.go
@@ -81,6 +81,10 @@ type Options struct {
 
 	// When Stat is not nil, statistical logic needs to be executed
 	Stat *Statistics
+
+	// When set to true, the DB will only keep the most recent version and immediately delete
+	// obsolete data upon new data's commit
+	NoVersioning bool
 }
 
 // DefaultOptions returns the default options for IAVL.


### PR DESCRIPTION
## Describe your changes and provide context
Add an option for node to opt out of versioning, in which case we will not set/read/delete orphan metadata for deleted versions but straight out delete them during new version commit.

## Testing performed to validate your change

