### PR TITLE
Separate orphan storage

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -634,18 +634,6 @@ func (ndb *nodeDB) SaveOrphans(version int64, orphans map[string]int64) error {
 	ndb.mtx.Lock()
 	defer ndb.mtx.Unlock()
 
-	// instead of saving orphan metadata and later read orphan metadata->delete
-	// orphan data->delete orphan metadata, we directly delete orphan data here
-	// without doing anything for orphan metadata, if versioning is not needed.
-	if ndb.ShouldNotUseVersion() {
-		for orphan := range orphans {
-			if err := ndb.deleteOrphanedData([]byte(orphan)); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
 	toVersion, err := ndb.getPreviousVersion(version)
 	if err != nil {
 		return err
@@ -1071,10 +1059,6 @@ func (ndb *nodeDB) traverseNodes(fn func(hash []byte, node *Node) error) error {
 		}
 	}
 	return nil
-}
-
-func (ndb *nodeDB) ShouldNotUseVersion() bool {
-	return ndb.opts.NoVersioning
 }
 
 func (ndb *nodeDB) String() (string, error) {

--- a/options.go
+++ b/options.go
@@ -82,12 +82,16 @@ type Options struct {
 	// When Stat is not nil, statistical logic needs to be executed
 	Stat *Statistics
 
-	// When set to true, the DB will only keep the most recent version and immediately delete
-	// obsolete data upon new data's commit
-	NoVersioning bool
+	VersionsToKeep int64
+
+	NumOrphansPerFile int
+
+	OrphanDirectory string
 }
 
 // DefaultOptions returns the default options for IAVL.
 func DefaultOptions() Options {
-	return Options{}
+	return Options{
+		NumOrphansPerFile: 100000,
+	}
 }

--- a/options.go
+++ b/options.go
@@ -82,10 +82,20 @@ type Options struct {
 	// When Stat is not nil, statistical logic needs to be executed
 	Stat *Statistics
 
-	VersionsToKeep int64
+	// When true, orphan data will be stored in separate directory than application data, and
+	// the pruning of application data will happen during commit (rather than after commit)
+	SeparateOrphanStorage bool
 
+	// Only meaningful if SeparateOrphanStorage is true.
+	// The number of application data versions to keep in the application database.
+	SeparateOphanVersionsToKeep int64
+
+	// Only meaningful if SeparateOrphanStorage is true.
+	// The max number of orphan entries to store in the separate orphan files.
 	NumOrphansPerFile int
 
+	// Only meaningful if SeparateOrphanStorage is true.
+	// The directory to store orphan files.
 	OrphanDirectory string
 }
 

--- a/orphandb.go
+++ b/orphandb.go
@@ -1,0 +1,75 @@
+package iavl
+
+import (
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+type orphanDB struct {
+	cache             map[int64]map[string]int64 // key: version, value: orphans
+	directory         string
+	numOrphansPerFile int
+}
+
+func NewOrphanDB(opts *Options) *orphanDB {
+	return &orphanDB{
+		cache:             map[int64]map[string]int64{},
+		directory:         opts.OrphanDirectory,
+		numOrphansPerFile: opts.NumOrphansPerFile,
+	}
+}
+
+func (o *orphanDB) SaveOrphans(version int64, orphans map[string]int64) error {
+	o.cache[version] = orphans
+	chunks := [][]string{{}}
+	for orphan := range orphans {
+		if len(chunks[len(chunks)-1]) == o.numOrphansPerFile {
+			chunks = append(chunks, []string{})
+		}
+		chunks[len(chunks)-1] = append(chunks[len(chunks)-1], orphan)
+	}
+	dir := path.Join(o.directory, fmt.Sprintf("%d", version))
+	os.RemoveAll(dir)
+	os.MkdirAll(dir, fs.ModePerm)
+	for i, chunk := range chunks {
+		f, err := os.Create(path.Join(dir, fmt.Sprintf("%d", i)))
+		if err != nil {
+			return err
+		}
+		f.WriteString(strings.Join(chunk, "\n"))
+		f.Close()
+	}
+	return nil
+}
+
+func (o *orphanDB) GetOrphans(version int64) map[string]int64 {
+	if _, ok := o.cache[version]; !ok {
+		o.cache[version] = map[string]int64{}
+		dir := path.Join(o.directory, fmt.Sprintf("%d", version))
+		files, err := ioutil.ReadDir(dir)
+		if err != nil {
+			// no orphans found
+			return o.cache[version]
+		}
+		for _, file := range files {
+			content, err := ioutil.ReadFile(path.Join(dir, file.Name()))
+			if err != nil {
+				return o.cache[version]
+			}
+			for _, orphan := range strings.Split(string(content), "\n") {
+				o.cache[version][orphan] = version
+			}
+		}
+	}
+	return o.cache[version]
+}
+
+func (o *orphanDB) DeleteOrphans(version int64) error {
+	delete(o.cache, version)
+	dir := path.Join(o.directory, fmt.Sprintf("%d", version))
+	return os.RemoveAll(dir)
+}

--- a/orphandb_test.go
+++ b/orphandb_test.go
@@ -1,0 +1,73 @@
+package iavl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrphanDBSaveGet(t *testing.T) {
+	dir := t.TempDir()
+	db := NewOrphanDB(&Options{
+		NumOrphansPerFile: 2,
+		OrphanDirectory:   dir,
+	})
+	err := db.SaveOrphans(123, map[string]int64{
+		"o1": 123,
+		"o2": 123,
+		"o3": 123,
+	})
+	require.Nil(t, err)
+	files, err := ioutil.ReadDir(path.Join(dir, fmt.Sprintf("%d", 123)))
+	require.Nil(t, err)
+	require.Equal(t, 2, len(files)) // 3 orphans would result in 2 files
+	orphans := db.GetOrphans(123)
+	require.Equal(t, map[string]int64{
+		"o1": 123,
+		"o2": 123,
+		"o3": 123,
+	}, orphans)
+	orphans = db.GetOrphans(456) // not exist
+	require.Equal(t, map[string]int64{}, orphans)
+
+	// flush cache
+	db = NewOrphanDB(&Options{
+		NumOrphansPerFile: 2,
+		OrphanDirectory:   dir,
+	})
+	orphans = db.GetOrphans(123) // would load from disk
+	require.Equal(t, map[string]int64{
+		"o1": 123,
+		"o2": 123,
+		"o3": 123,
+	}, orphans)
+}
+
+func TestOrphanDelete(t *testing.T) {
+	dir := t.TempDir()
+	db := NewOrphanDB(&Options{
+		NumOrphansPerFile: 2,
+		OrphanDirectory:   dir,
+	})
+	err := db.SaveOrphans(123, map[string]int64{
+		"o1": 123,
+		"o2": 123,
+		"o3": 123,
+	})
+	require.Nil(t, err)
+	err = db.DeleteOrphans(123)
+	require.Nil(t, err)
+	orphans := db.GetOrphans(123) // not exist in cache
+	require.Equal(t, map[string]int64{}, orphans)
+
+	// flush cache
+	db = NewOrphanDB(&Options{
+		NumOrphansPerFile: 2,
+		OrphanDirectory:   dir,
+	})
+	orphans = db.GetOrphans(123) // would load from disk
+	require.Equal(t, map[string]int64{}, orphans)
+}


### PR DESCRIPTION
## Describe your changes and provide context
Add a new option that stores orphan separate from the main application data to maximize data locality for orphan data which, for a given version, is always read and written together. It also removes the need for expensive calls like `getPreviousVersion` so that the overall latency is further improved.

Specifically, if this option is on, orphan data would be stored as plain files cataloged by the committing version that resulted in the orphans, and also cached in memory. Most of the time, orphans will be read from the memory and used to delete obsolete data in the application DB, after which the corresponding orphan version directory will be removed as a whole. In the rare event of crash or process restarts, orphan data would be read from the orphan files.

## Testing performed to validate your change
unit test & testing on atlantic-2

