### PR TITLE
Synchronize potential concurrent access to mutable tree

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -42,7 +42,7 @@ func TestBasic(t *testing.T) {
 		key := []byte{0x00}
 		expected := ""
 
-		idx, val, err := tree.GetWithIndex(key)
+		idx, val, err := tree.ImmutableTree().GetWithIndex(key)
 		require.NoError(t, err)
 		if val != nil {
 			t.Error("Expected no value to exist")
@@ -68,7 +68,7 @@ func TestBasic(t *testing.T) {
 		key := []byte("1")
 		expected := "one"
 
-		idx, val, err := tree.GetWithIndex(key)
+		idx, val, err := tree.ImmutableTree().GetWithIndex(key)
 		require.NoError(t, err)
 		if val == nil {
 			t.Error("Expected value to exist")
@@ -95,7 +95,7 @@ func TestBasic(t *testing.T) {
 		key := []byte("2")
 		expected := "TWO"
 
-		idx, val, err := tree.GetWithIndex(key)
+		idx, val, err := tree.ImmutableTree().GetWithIndex(key)
 		require.NoError(t, err)
 		if val == nil {
 			t.Error("Expected value to exist")
@@ -121,7 +121,7 @@ func TestBasic(t *testing.T) {
 		key := []byte("4")
 		expected := ""
 
-		idx, val, err := tree.GetWithIndex(key)
+		idx, val, err := tree.ImmutableTree().GetWithIndex(key)
 		require.NoError(t, err)
 		if val != nil {
 			t.Error("Expected no value to exist")
@@ -147,7 +147,7 @@ func TestBasic(t *testing.T) {
 		key := []byte("6")
 		expected := ""
 
-		idx, val, err := tree.GetWithIndex(key)
+		idx, val, err := tree.ImmutableTree().GetWithIndex(key)
 		require.NoError(t, err)
 		if val != nil {
 			t.Error("Expected no value to exist")
@@ -192,31 +192,31 @@ func TestUnit(t *testing.T) {
 	}
 
 	expectSet := func(tree *MutableTree, i int, repr string, hashCount int64) {
-		origNode := tree.root
+		origNode := tree.ImmutableTree().root
 		updated, err := tree.Set(i2b(i), []byte{})
 		require.NoError(t, err)
 		// ensure node was added & structure is as expected.
-		if updated || P(tree.root) != repr {
+		if updated || P(tree.ImmutableTree().root) != repr {
 			t.Fatalf("Adding %v to %v:\nExpected         %v\nUnexpectedly got %v updated:%v",
-				i, P(origNode), repr, P(tree.root), updated)
+				i, P(origNode), repr, P(tree.ImmutableTree().root), updated)
 		}
 		// ensure hash calculation requirements
-		expectHash(tree.ImmutableTree, hashCount)
-		tree.root = origNode
+		expectHash(tree.ImmutableTree(), hashCount)
+		tree.ImmutableTree().root = origNode
 	}
 
 	expectRemove := func(tree *MutableTree, i int, repr string, hashCount int64) {
-		origNode := tree.root
+		origNode := tree.ImmutableTree().root
 		value, removed, err := tree.Remove(i2b(i))
 		require.NoError(t, err)
 		// ensure node was added & structure is as expected.
-		if len(value) != 0 || !removed || P(tree.root) != repr {
+		if len(value) != 0 || !removed || P(tree.ImmutableTree().root) != repr {
 			t.Fatalf("Removing %v from %v:\nExpected         %v\nUnexpectedly got %v value:%v removed:%v",
-				i, P(origNode), repr, P(tree.root), value, removed)
+				i, P(origNode), repr, P(tree.ImmutableTree().root), value, removed)
 		}
 		// ensure hash calculation requirements
-		expectHash(tree.ImmutableTree, hashCount)
-		tree.root = origNode
+		expectHash(tree.ImmutableTree(), hashCount)
+		tree.ImmutableTree().root = origNode
 	}
 
 	// Test Set cases:
@@ -317,8 +317,8 @@ func TestIntegration(t *testing.T) {
 		if !updated {
 			t.Error("should have been updated")
 		}
-		if tree.Size() != int64(i+1) {
-			t.Error("size was wrong", tree.Size(), i+1)
+		if tree.ImmutableTree().Size() != int64(i+1) {
+			t.Error("size was wrong", tree.ImmutableTree().Size(), i+1)
 		}
 	}
 
@@ -370,8 +370,8 @@ func TestIntegration(t *testing.T) {
 				t.Error("wrong value")
 			}
 		}
-		if tree.Size() != int64(len(records)-(i+1)) {
-			t.Error("size was wrong", tree.Size(), (len(records) - (i + 1)))
+		if tree.ImmutableTree().Size() != int64(len(records)-(i+1)) {
+			t.Error("size was wrong", tree.ImmutableTree().Size(), (len(records) - (i + 1)))
 		}
 	}
 }
@@ -427,38 +427,38 @@ func TestIterateRange(t *testing.T) {
 	}
 
 	trav := traverser{}
-	tree.IterateRange([]byte("foo"), []byte("goo"), true, trav.view)
+	tree.ImmutableTree().IterateRange([]byte("foo"), []byte("goo"), true, trav.view)
 	expectTraverse(t, trav, "foo", "food", 5)
 
 	trav = traverser{}
-	tree.IterateRange([]byte("aaa"), []byte("abb"), true, trav.view)
+	tree.ImmutableTree().IterateRange([]byte("aaa"), []byte("abb"), true, trav.view)
 	expectTraverse(t, trav, "", "", 0)
 
 	trav = traverser{}
-	tree.IterateRange(nil, []byte("flap"), true, trav.view)
+	tree.ImmutableTree().IterateRange(nil, []byte("flap"), true, trav.view)
 	expectTraverse(t, trav, "abc", "fan", 2)
 
 	trav = traverser{}
-	tree.IterateRange([]byte("foob"), nil, true, trav.view)
+	tree.ImmutableTree().IterateRange([]byte("foob"), nil, true, trav.view)
 	expectTraverse(t, trav, "foobang", "low", 6)
 
 	trav = traverser{}
-	tree.IterateRange([]byte("very"), nil, true, trav.view)
+	tree.ImmutableTree().IterateRange([]byte("very"), nil, true, trav.view)
 	expectTraverse(t, trav, "", "", 0)
 
 	// make sure it doesn't include end
 	trav = traverser{}
-	tree.IterateRange([]byte("fooba"), []byte("food"), true, trav.view)
+	tree.ImmutableTree().IterateRange([]byte("fooba"), []byte("food"), true, trav.view)
 	expectTraverse(t, trav, "foobang", "foobaz", 3)
 
 	// make sure backwards also works... (doesn't include end)
 	trav = traverser{}
-	tree.IterateRange([]byte("fooba"), []byte("food"), false, trav.view)
+	tree.ImmutableTree().IterateRange([]byte("fooba"), []byte("food"), false, trav.view)
 	expectTraverse(t, trav, "foobaz", "foobang", 3)
 
 	// make sure backwards also works...
 	trav = traverser{}
-	tree.IterateRange([]byte("g"), nil, false, trav.view)
+	tree.ImmutableTree().IterateRange([]byte("g"), nil, false, trav.view)
 	expectTraverse(t, trav, "low", "good", 2)
 }
 
@@ -513,7 +513,7 @@ func TestProof(t *testing.T) {
 
 	// Now for each item, construct a proof and verify
 	tree.Iterate(func(key []byte, value []byte) bool {
-		value2, proof, err := tree.GetWithProof(key)
+		value2, proof, err := tree.ImmutableTree().GetWithProof(key)
 		assert.NoError(t, err)
 		assert.Equal(t, value, value2)
 		if assert.NotNil(t, proof) {
@@ -534,7 +534,7 @@ func TestTreeProof(t *testing.T) {
 	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hex.EncodeToString(hash))
 
 	// should get false for proof with nil root
-	value, proof, err := tree.GetWithProof([]byte("foo"))
+	value, proof, err := tree.ImmutableTree().GetWithProof([]byte("foo"))
 	assert.Nil(t, value)
 	assert.Nil(t, proof)
 	assert.Error(t, proof.Verify([]byte(nil)))
@@ -551,7 +551,7 @@ func TestTreeProof(t *testing.T) {
 	tree.SaveVersion()
 
 	// query random key fails
-	value, proof, err = tree.GetWithProof([]byte("foo"))
+	value, proof, err = tree.ImmutableTree().GetWithProof([]byte("foo"))
 	assert.Nil(t, value)
 	assert.NotNil(t, proof)
 	assert.NoError(t, err)
@@ -564,7 +564,7 @@ func TestTreeProof(t *testing.T) {
 	root, err := tree.WorkingHash()
 	assert.NoError(t, err)
 	for _, key := range keys {
-		value, proof, err := tree.GetWithProof(key)
+		value, proof, err := tree.ImmutableTree().GetWithProof(key)
 		if assert.NoError(t, err) {
 			require.Nil(t, err, "Failed to read proof from bytes: %v", err)
 			assert.Equal(t, key, value)

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -58,7 +58,7 @@ func commitTree(b *testing.B, t *iavl.MutableTree) {
 
 // queries random keys against live state. Keys are almost certainly not in the tree.
 func runQueriesFast(b *testing.B, t *iavl.MutableTree, keyLen int) {
-	isFastCacheEnabled, err := t.IsFastCacheEnabled()
+	isFastCacheEnabled, err := t.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(b, err)
 	require.True(b, isFastCacheEnabled)
 	for i := 0; i < b.N; i++ {
@@ -69,7 +69,7 @@ func runQueriesFast(b *testing.B, t *iavl.MutableTree, keyLen int) {
 
 // queries keys that are known to be in state
 func runKnownQueriesFast(b *testing.B, t *iavl.MutableTree, keys [][]byte) {
-	isFastCacheEnabled, err := t.IsFastCacheEnabled() // to ensure fast storage is enabled
+	isFastCacheEnabled, err := t.ImmutableTree().IsFastCacheEnabled() // to ensure fast storage is enabled
 	require.NoError(b, err)
 	require.True(b, isFastCacheEnabled)
 	l := int32(len(keys))
@@ -123,11 +123,11 @@ func runKnownQueriesSlow(b *testing.B, t *iavl.MutableTree, keys [][]byte) {
 }
 
 func runIterationFast(b *testing.B, t *iavl.MutableTree, expectedSize int) {
-	isFastCacheEnabled, err := t.IsFastCacheEnabled()
+	isFastCacheEnabled, err := t.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(b, err)
 	require.True(b, isFastCacheEnabled) // to ensure fast storage is enabled
 	for i := 0; i < b.N; i++ {
-		itr, err := t.ImmutableTree.Iterator(nil, nil, false)
+		itr, err := t.ImmutableTree().Iterator(nil, nil, false)
 		require.NoError(b, err)
 		iterate(b, itr, expectedSize)
 		require.Nil(b, itr.Close(), ".Close should not error out")
@@ -136,7 +136,7 @@ func runIterationFast(b *testing.B, t *iavl.MutableTree, expectedSize int) {
 
 func runIterationSlow(b *testing.B, t *iavl.MutableTree, expectedSize int) {
 	for i := 0; i < b.N; i++ {
-		itr := iavl.NewIterator(nil, nil, false, t.ImmutableTree) // create slow iterator directly
+		itr := iavl.NewIterator(nil, nil, false, t.ImmutableTree()) // create slow iterator directly
 		iterate(b, itr, expectedSize)
 		require.Nil(b, itr.Close(), ".Close should not error out")
 	}

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -49,7 +49,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error hashing tree: %s\n", err)
 		os.Exit(1)
 	}
-	fmt.Printf("Tree hash is %X, tree size is %X\n", treeHash, tree.Size())
+	fmt.Printf("Tree hash is %X, tree size is %X\n", treeHash, tree.ImmutableTree().Size())
 
 	switch args[0] {
 	case "data":
@@ -60,7 +60,7 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Printf("Hash: %X\n", hash)
-		fmt.Printf("Size: %X\n", tree.Size())
+		fmt.Printf("Size: %X\n", tree.ImmutableTree().Size())
 	case "shape":
 		PrintShape(tree)
 	case "versions":
@@ -181,7 +181,7 @@ func encodeID(id []byte) string {
 func PrintShape(tree *iavl.MutableTree) {
 	// shape := tree.RenderShape("  ", nil)
 	//TODO: handle this error
-	shape, _ := tree.RenderShape("  ", nodeEncoder)
+	shape, _ := tree.ImmutableTree().RenderShape("  ", nodeEncoder)
 	fmt.Println(strings.Join(shape, "\n"))
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -102,7 +102,7 @@ func setupExportTreeRandom(t *testing.T) *ImmutableTree {
 	}
 
 	require.EqualValues(t, versions, tree.Version())
-	require.GreaterOrEqual(t, tree.Size(), int64(math.Trunc(versions*versionOps*(1-updateRatio-deleteRatio))/2))
+	require.GreaterOrEqual(t, tree.ImmutableTree().Size(), int64(math.Trunc(versions*versionOps*(1-updateRatio-deleteRatio))/2))
 
 	itree, err := tree.GetImmutable(version)
 	require.NoError(t, err)
@@ -216,13 +216,13 @@ func TestExporter_Import(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, treeHash, newTreeHash, "Tree hash mismatch")
-			require.Equal(t, tree.Size(), newTree.Size(), "Tree size mismatch")
+			require.Equal(t, tree.Size(), newTree.ImmutableTree().Size(), "Tree size mismatch")
 			require.Equal(t, tree.Version(), newTree.Version(), "Tree version mismatch")
 
 			tree.Iterate(func(key, value []byte) bool {
 				index, _, err := tree.GetWithIndex(key)
 				require.NoError(t, err)
-				newIndex, newValue, err := newTree.GetWithIndex(key)
+				newIndex, newValue, err := newTree.ImmutableTree().GetWithIndex(key)
 				require.NoError(t, err)
 				require.Equal(t, index, newIndex, "Index mismatch for key %v", key)
 				require.Equal(t, value, newValue, "Value mismatch for key %v", key)

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -105,7 +105,7 @@ func TestTraverse(t *testing.T) {
 		tree.set([]byte(fmt.Sprintf("k%d", i)), []byte(fmt.Sprintf("v%d", i)))
 	}
 
-	require.Equal(t, 11, tree.nodeSize(), "Size of tree unexpected")
+	require.Equal(t, 11, tree.ImmutableTree().nodeSize(), "Size of tree unexpected")
 }
 
 func TestMutableTree_DeleteVersions(t *testing.T) {
@@ -435,7 +435,7 @@ func TestMutableTree_LazyLoadVersionWithEmptyTree(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, v1 == v2)
 
-	require.True(t, newTree1.root == newTree2.root)
+	require.True(t, newTree1.ImmutableTree().root == newTree2.ImmutableTree().root)
 }
 
 func TestMutableTree_SetSimple(t *testing.T) {
@@ -452,7 +452,7 @@ func TestMutableTree_SetSimple(t *testing.T) {
 
 	fastValue, err := tree.Get([]byte(testKey1))
 	require.NoError(t, err)
-	_, regularValue, err := tree.GetWithIndex([]byte(testKey1))
+	_, regularValue, err := tree.ImmutableTree().GetWithIndex([]byte(testKey1))
 	require.NoError(t, err)
 
 	require.Equal(t, []byte(testVal1), fastValue)
@@ -486,14 +486,14 @@ func TestMutableTree_SetTwoKeys(t *testing.T) {
 
 	fastValue, err := tree.Get([]byte(testKey1))
 	require.NoError(t, err)
-	_, regularValue, err := tree.GetWithIndex([]byte(testKey1))
+	_, regularValue, err := tree.ImmutableTree().GetWithIndex([]byte(testKey1))
 	require.NoError(t, err)
 	require.Equal(t, []byte(testVal1), fastValue)
 	require.Equal(t, []byte(testVal1), regularValue)
 
 	fastValue2, err := tree.Get([]byte(testKey2))
 	require.NoError(t, err)
-	_, regularValue2, err := tree.GetWithIndex([]byte(testKey2))
+	_, regularValue2, err := tree.ImmutableTree().GetWithIndex([]byte(testKey2))
 	require.NoError(t, err)
 	require.Equal(t, []byte(testVal2), fastValue2)
 	require.Equal(t, []byte(testVal2), regularValue2)
@@ -528,7 +528,7 @@ func TestMutableTree_SetOverwrite(t *testing.T) {
 
 	fastValue, err := tree.Get([]byte(testKey1))
 	require.NoError(t, err)
-	_, regularValue, err := tree.GetWithIndex([]byte(testKey1))
+	_, regularValue, err := tree.ImmutableTree().GetWithIndex([]byte(testKey1))
 	require.NoError(t, err)
 	require.Equal(t, []byte(testVal2), fastValue)
 	require.Equal(t, []byte(testVal2), regularValue)
@@ -554,7 +554,7 @@ func TestMutableTree_SetRemoveSet(t *testing.T) {
 
 	fastValue, err := tree.Get([]byte(testKey1))
 	require.NoError(t, err)
-	_, regularValue, err := tree.GetWithIndex([]byte(testKey1))
+	_, regularValue, err := tree.ImmutableTree().GetWithIndex([]byte(testKey1))
 	require.Equal(t, []byte(testVal1), fastValue)
 	require.Equal(t, []byte(testVal1), regularValue)
 
@@ -580,7 +580,7 @@ func TestMutableTree_SetRemoveSet(t *testing.T) {
 
 	fastValue, err = tree.Get([]byte(testKey1))
 	require.NoError(t, err)
-	_, regularValue, err = tree.GetWithIndex([]byte(testKey1))
+	_, regularValue, err = tree.ImmutableTree().GetWithIndex([]byte(testKey1))
 	require.NoError(t, err)
 	require.Nil(t, fastValue)
 	require.Nil(t, regularValue)
@@ -592,7 +592,7 @@ func TestMutableTree_SetRemoveSet(t *testing.T) {
 
 	fastValue, err = tree.Get([]byte(testKey1))
 	require.NoError(t, err)
-	_, regularValue, err = tree.GetWithIndex([]byte(testKey1))
+	_, regularValue, err = tree.ImmutableTree().GetWithIndex([]byte(testKey1))
 	require.NoError(t, err)
 	require.Equal(t, []byte(testVal1), fastValue)
 	require.Equal(t, []byte(testVal1), regularValue)
@@ -685,21 +685,21 @@ func TestMutableTree_FastNodeIntegration(t *testing.T) {
 	// Get and GetFast
 	fastValue, err := t2.Get([]byte(key1))
 	require.NoError(t, err)
-	_, regularValue, err := tree.GetWithIndex([]byte(key1))
+	_, regularValue, err := tree.ImmutableTree().GetWithIndex([]byte(key1))
 	require.NoError(t, err)
 	require.Equal(t, []byte(testVal1), fastValue)
 	require.Equal(t, []byte(testVal1), regularValue)
 
 	fastValue, err = t2.Get([]byte(key2))
 	require.NoError(t, err)
-	_, regularValue, err = t2.GetWithIndex([]byte(key2))
+	_, regularValue, err = t2.ImmutableTree().GetWithIndex([]byte(key2))
 	require.NoError(t, err)
 	require.Nil(t, fastValue)
 	require.Nil(t, regularValue)
 
 	fastValue, err = t2.Get([]byte(key3))
 	require.NoError(t, err)
-	_, regularValue, err = tree.GetWithIndex([]byte(key3))
+	_, regularValue, err = tree.ImmutableTree().GetWithIndex([]byte(key3))
 	require.NoError(t, err)
 	require.Equal(t, []byte(testVal2), fastValue)
 	require.Equal(t, []byte(testVal2), regularValue)
@@ -749,7 +749,7 @@ func TestUpgradeStorageToFast_LatestVersion_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// Default version when storage key does not exist in the db
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -768,7 +768,7 @@ func TestUpgradeStorageToFast_LatestVersion_Success(t *testing.T) {
 	require.False(t, isUpgradeable)
 	require.NoError(t, err)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 }
@@ -780,7 +780,7 @@ func TestUpgradeStorageToFast_AlreadyUpgraded_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// Default version when storage key does not exist in the db
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -795,7 +795,7 @@ func TestUpgradeStorageToFast_AlreadyUpgraded_Success(t *testing.T) {
 	enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
 	require.NoError(t, err)
 	require.True(t, enabled)
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 	isUpgradeable, err = tree.IsUpgradeable()
@@ -806,7 +806,7 @@ func TestUpgradeStorageToFast_AlreadyUpgraded_Success(t *testing.T) {
 	enabled, err = tree.enableFastStorageAndCommitIfNotEnabled()
 	require.NoError(t, err)
 	require.False(t, enabled)
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 
@@ -832,7 +832,7 @@ func TestUpgradeStorageToFast_DbErrorConstructor_Failure(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, tree)
 
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 }
@@ -867,7 +867,7 @@ func TestUpgradeStorageToFast_DbErrorEnableFastStorage_Failure(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, tree)
 
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -875,7 +875,7 @@ func TestUpgradeStorageToFast_DbErrorEnableFastStorage_Failure(t *testing.T) {
 	require.ErrorIs(t, err, expectedError)
 	require.False(t, enabled)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 }
@@ -909,13 +909,13 @@ func TestFastStorageReUpgradeProtection_NoForceUpgrade_Success(t *testing.T) {
 	require.NotNil(t, tree)
 
 	// Pretend that we called Load and have the latest state in the tree
-	tree.version = latestTreeVersion
+	tree.ImmutableTree().version = latestTreeVersion
 	latestVersion, err := tree.ndb.getLatestVersion()
 	require.NoError(t, err)
 	require.Equal(t, latestVersion, int64(latestTreeVersion))
 
 	// Ensure that the right branch of enableFastStorageAndCommitIfNotEnabled will be triggered
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 	shouldForce, err := tree.ndb.shouldForceFastStorageUpgrade()
@@ -1002,13 +1002,13 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 	require.NotNil(t, tree)
 
 	// Pretend that we called Load and have the latest state in the tree
-	tree.version = latestTreeVersion
+	tree.ImmutableTree().version = latestTreeVersion
 	latestVersion, err := tree.ndb.getLatestVersion()
 	require.NoError(t, err)
 	require.Equal(t, latestVersion, int64(latestTreeVersion))
 
 	// Ensure that the right branch of enableFastStorageAndCommitIfNotEnabled will be triggered
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 	shouldForce, err := tree.ndb.shouldForceFastStorageUpgrade()
@@ -1030,7 +1030,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 	// Setup
 	tree, mirror := setupTreeAndMirror(t, 100, false)
 
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err := tree.IsUpgradeable()
@@ -1041,7 +1041,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 	isUpgradeable, err = tree.IsUpgradeable()
@@ -1050,7 +1050,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 
 	sut, _ := NewMutableTree(tree.ndb.db, 1000, false)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err = sut.IsUpgradeable()
@@ -1061,7 +1061,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 	version, err := sut.Load()
 	require.NoError(t, err)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 
@@ -1080,7 +1080,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 
 	// Test that upgraded immutable tree iterates as expected
 	t.Run("Immutable tree", func(t *testing.T) {
-		immutableTree, err := sut.GetImmutable(sut.version)
+		immutableTree, err := sut.GetImmutable(sut.ImmutableTree().version)
 		require.NoError(t, err)
 
 		i := 0
@@ -1097,7 +1097,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 	// Setup
 	tree, mirror := setupTreeAndMirror(t, 100, false)
 
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err := tree.IsUpgradeable()
@@ -1108,7 +1108,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 	isUpgradeable, err = tree.IsUpgradeable()
@@ -1117,7 +1117,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 
 	sut, _ := NewMutableTree(tree.ndb.db, 1000, false)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err = sut.IsUpgradeable()
@@ -1128,7 +1128,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 	version, err := sut.LazyLoadVersion(1)
 	require.NoError(t, err)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.True(t, isFastCacheEnabled)
 
@@ -1143,7 +1143,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 	})
 
 	t.Run("Immutable tree", func(t *testing.T) {
-		immutableTree, err := sut.GetImmutable(sut.version)
+		immutableTree, err := sut.GetImmutable(sut.ImmutableTree().version)
 		require.NoError(t, err)
 
 		for _, kv := range mirror {
@@ -1284,7 +1284,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 	// Setup
 	tree, mirror := setupTreeAndMirror(t, 100, true)
 
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err := tree.IsUpgradeable()
@@ -1295,7 +1295,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err = tree.IsUpgradeable()
@@ -1304,7 +1304,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 
 	sut, _ := NewMutableTree(tree.ndb.db, 1000, true)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err = sut.IsUpgradeable()
@@ -1316,7 +1316,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 	require.NoError(t, err)
 	require.Equal(t, int64(1), version)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -1325,7 +1325,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 	require.NoError(t, err)
 	require.Equal(t, int64(1), version)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -1334,7 +1334,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 	require.NoError(t, err)
 	require.Equal(t, int64(1), version)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -1343,7 +1343,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 	require.NoError(t, err)
 	require.Equal(t, int64(1), version)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -1356,7 +1356,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testin
 	})
 
 	t.Run("Immutable tree", func(t *testing.T) {
-		immutableTree, err := sut.GetImmutable(sut.version)
+		immutableTree, err := sut.GetImmutable(sut.ImmutableTree().version)
 		require.NoError(t, err)
 
 		for _, kv := range mirror {
@@ -1371,7 +1371,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *te
 	// Setup
 	tree, mirror := setupTreeAndMirror(t, 100, true)
 
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err := tree.IsUpgradeable()
@@ -1382,7 +1382,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *te
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err = tree.IsUpgradeable()
@@ -1391,7 +1391,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *te
 
 	sut, _ := NewMutableTree(tree.ndb.db, 1000, true)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 	isUpgradeable, err = sut.IsUpgradeable()
@@ -1403,7 +1403,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *te
 	require.NoError(t, err)
 	require.Equal(t, int64(1), version)
 
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
+	isFastCacheEnabled, err = sut.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -1412,7 +1412,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *te
 	require.NoError(t, err)
 	require.Equal(t, int64(1), version)
 
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
+	isFastCacheEnabled, err = tree.ImmutableTree().IsFastCacheEnabled()
 	require.NoError(t, err)
 	require.False(t, isFastCacheEnabled)
 
@@ -1429,7 +1429,7 @@ func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *te
 
 	// Test that the immutable tree iterates as expected
 	t.Run("Immutable tree", func(t *testing.T) {
-		immutableTree, err := sut.GetImmutable(sut.version)
+		immutableTree, err := sut.GetImmutable(sut.ImmutableTree().version)
 		require.NoError(t, err)
 
 		i := 0
@@ -1463,7 +1463,7 @@ func TestSaveCurrentVersion_BadVersion(t *testing.T) {
 	_, version, err := tree.SaveVersion()
 	require.NoError(t, err)
 	assert.EqualValues(t, 9, version)
-	tree.version = 10
+	tree.ImmutableTree().version = 10
 	_, version, err = tree.SaveCurrentVersion()
 	require.Error(t, err)
 	assert.EqualValues(t, 10, version)

--- a/proof_forgery_test.go
+++ b/proof_forgery_test.go
@@ -37,7 +37,7 @@ func TestProofFogery(t *testing.T) {
 	k := []byte{keys[1]}
 	v := values[1]
 
-	val, proof, err := tree.GetWithProof(k)
+	val, proof, err := tree.ImmutableTree().GetWithProof(k)
 	require.NoError(t, err)
 
 	err = proof.Verify(root)
@@ -53,7 +53,7 @@ func TestProofFogery(t *testing.T) {
 	// - a new leaf node to the right
 	// - an empty inner node
 	// - a right entry in the path
-	_, proof2, _ := tree.GetWithProof(k)
+	_, proof2, _ := tree.ImmutableTree().GetWithProof(k)
 	forgedNode := proof2.Leaves[0]
 	forgedNode.Key = []byte{0xFF}
 	forgedNode.ValueHash = forgedValueHash

--- a/proof_iavl_test.go
+++ b/proof_iavl_test.go
@@ -44,7 +44,7 @@ func TestProofOp(t *testing.T) {
 		tc := tc
 		t.Run(fmt.Sprintf("%02x", tc.key), func(t *testing.T) {
 			key := []byte{tc.key}
-			value, proof, err := tree.GetWithProof(key)
+			value, proof, err := tree.ImmutableTree().GetWithProof(key)
 			require.NoError(t, err)
 
 			// Verify that proof is valid.

--- a/proof_ics23_test.go
+++ b/proof_ics23_test.go
@@ -48,7 +48,7 @@ func TestGetMembership(t *testing.T) {
 			key := GetKey(allkeys, tc.loc)
 			val, err := tree.Get(key)
 			require.NoError(t, err)
-			proof, err := tree.GetMembershipProof(key)
+			proof, err := tree.ImmutableTree().GetMembershipProof(key)
 			require.NoError(t, err, "Creating Proof: %+v", err)
 
 			root, err := tree.Hash()
@@ -77,7 +77,7 @@ func TestGetNonMembership(t *testing.T) {
 	performTest := func(tree *MutableTree, allKeys [][]byte, loc Where) {
 		key := GetNonKey(allKeys, loc)
 
-		proof, err := tree.GetNonMembershipProof(key)
+		proof, err := tree.ImmutableTree().GetNonMembershipProof(key)
 		require.NoError(t, err, "Creating Proof: %+v", err)
 
 		root, err := tree.Hash()
@@ -97,7 +97,7 @@ func TestGetNonMembership(t *testing.T) {
 			_, _, err = tree.SaveVersion()
 			require.NoError(t, err)
 
-			isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+			isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 			require.NoError(t, err)
 			require.True(t, isFastCacheEnabled)
 
@@ -107,7 +107,7 @@ func TestGetNonMembership(t *testing.T) {
 		t.Run("regular-"+name, func(t *testing.T) {
 			tree, allkeys, err := BuildTree(tc.size, 0)
 			require.NoError(t, err, "Creating tree: %+v", err)
-			isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+			isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 			require.NoError(t, err)
 			require.False(t, isFastCacheEnabled)
 
@@ -132,7 +132,7 @@ func BenchmarkGetNonMembership(b *testing.B) {
 	performTest := func(tree *MutableTree, allKeys [][]byte, loc Where) {
 		key := GetNonKey(allKeys, loc)
 
-		proof, err := tree.GetNonMembershipProof(key)
+		proof, err := tree.ImmutableTree().GetNonMembershipProof(key)
 		require.NoError(b, err, "Creating Proof: %+v", err)
 
 		b.StopTimer()
@@ -157,7 +157,7 @@ func BenchmarkGetNonMembership(b *testing.B) {
 			_, _, err = tree.SaveVersion()
 			require.NoError(b, err)
 
-			isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+			isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 			require.NoError(b, err)
 			require.True(b, isFastCacheEnabled)
 			b.StartTimer()
@@ -173,7 +173,7 @@ func BenchmarkGetNonMembership(b *testing.B) {
 
 			tree, allkeys, err := BuildTree(tc.size, 100000)
 			require.NoError(b, err, "Creating tree: %+v", err)
-			isFastCacheEnabled, err := tree.IsFastCacheEnabled()
+			isFastCacheEnabled, err := tree.ImmutableTree().IsFastCacheEnabled()
 			require.NoError(b, err)
 			require.False(b, isFastCacheEnabled)
 
@@ -207,7 +207,7 @@ func GenerateResult(size int, loc Where) (*Result, error) {
 	}
 	key := GetKey(allkeys, loc)
 
-	value, proof, err := tree.GetWithProof(key)
+	value, proof, err := tree.ImmutableTree().GetWithProof(key)
 	if err != nil {
 		return nil, err
 	}

--- a/proof_test.go
+++ b/proof_test.go
@@ -26,7 +26,7 @@ func TestTreeGetWithProof(t *testing.T) {
 	require.NoError(err)
 
 	key := []byte{0x32}
-	val, proof, err := tree.GetWithProof(key)
+	val, proof, err := tree.ImmutableTree().GetWithProof(key)
 	require.NoError(err)
 	require.NotEmpty(val)
 	require.NotNil(proof)
@@ -41,7 +41,7 @@ func TestTreeGetWithProof(t *testing.T) {
 	require.NoError(err, "%+v", err)
 
 	key = []byte{0x1}
-	val, proof, err = tree.GetWithProof(key)
+	val, proof, err = tree.ImmutableTree().GetWithProof(key)
 	require.NoError(err)
 	require.Empty(val)
 	require.NotNil(proof)
@@ -63,7 +63,7 @@ func TestTreeKeyExistsProof(t *testing.T) {
 	require.NoError(t, err)
 
 	// should get false for proof with nil root
-	proof, keys, values, err := tree.getRangeProof([]byte("foo"), nil, 1)
+	proof, keys, values, err := tree.ImmutableTree().getRangeProof([]byte("foo"), nil, 1)
 	assert.Nil(t, proof)
 	assert.Error(t, proof.Verify(root))
 	assert.Nil(t, keys)
@@ -83,13 +83,13 @@ func TestTreeKeyExistsProof(t *testing.T) {
 	require.NoError(t, err)
 
 	// query random key fails
-	proof, _, _, err = tree.getRangeProof([]byte("foo"), nil, 2)
+	proof, _, _, err = tree.ImmutableTree().getRangeProof([]byte("foo"), nil, 2)
 	assert.Nil(t, err)
 	assert.Nil(t, proof.Verify(root))
 	assert.Nil(t, proof.VerifyAbsence([]byte("foo")), proof.String())
 
 	// query min key fails
-	proof, _, _, err = tree.getRangeProof([]byte{0x00}, []byte{0x01}, 2)
+	proof, _, _, err = tree.ImmutableTree().getRangeProof([]byte{0x00}, []byte{0x01}, 2)
 	assert.Nil(t, err)
 	assert.Nil(t, proof.Verify(root))
 	assert.Nil(t, proof.VerifyAbsence([]byte{0x00}))
@@ -97,7 +97,7 @@ func TestTreeKeyExistsProof(t *testing.T) {
 	// valid proof for real keys
 	for i, key := range allkeys {
 		var keys, values [][]byte
-		proof, keys, values, err = tree.getRangeProof(key, nil, 2)
+		proof, keys, values, err = tree.ImmutableTree().getRangeProof(key, nil, 2)
 		require.Nil(t, err)
 
 		require.Equal(t,
@@ -186,7 +186,7 @@ func TestTreeKeyInRangeProofs(t *testing.T) {
 		end := []byte{c.end}
 
 		// Compute range proof.
-		keys, values, proof, err := tree.GetRangeWithProof(start, end, 0)
+		keys, values, proof, err := tree.ImmutableTree().GetRangeWithProof(start, end, 0)
 
 		if c.err {
 			require.Error(err, "%+v", err)

--- a/repair_test.go
+++ b/repair_test.go
@@ -84,7 +84,7 @@ func TestRepair013Orphans(t *testing.T) {
 // assertVersion checks the given version (or current if 0) against the expected values.
 func assertVersion(t *testing.T, tree *MutableTree, version int64) {
 	var err error
-	itree := tree.ImmutableTree
+	itree := tree.ImmutableTree()
 	if version > 0 {
 		itree, err = tree.GetImmutable(version)
 		require.NoError(t, err)

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -78,7 +78,7 @@ func T(n *Node) (*MutableTree, error) {
 	if err != nil {
 		return nil, err
 	}
-	t.root = n
+	t.ImmutableTree().root = n
 	return t, nil
 }
 

--- a/tree_dotgraph_test.go
+++ b/tree_dotgraph_test.go
@@ -16,5 +16,5 @@ func TestWriteDOTGraph(t *testing.T) {
 		key := []byte{ikey}
 		tree.Set(key, key)
 	}
-	WriteDOTGraph(ioutil.Discard, tree.ImmutableTree, []PathToLeaf{})
+	WriteDOTGraph(ioutil.Discard, tree.ImmutableTree(), []PathToLeaf{})
 }

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -152,7 +152,7 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		require.NoError(t, err)
 
 		t.Logf("Saved tree at version %v with %v keys and %v versions",
-			version, tree.Size(), len(tree.AvailableVersions()))
+			version, tree.ImmutableTree().Size(), len(tree.AvailableVersions()))
 
 		// Verify that the version matches the mirror.
 		assertMirror(t, tree, mirror, 0)
@@ -391,7 +391,7 @@ func assertMaxVersion(t *testing.T, tree *MutableTree, version int64, mirrors ma
 // Checks that a mirror, optionally for a given version, matches the tree contents.
 func assertMirror(t *testing.T, tree *MutableTree, mirror map[string]string, version int64) {
 	var err error
-	itree := tree.ImmutableTree
+	itree := tree.ImmutableTree()
 	if version > 0 {
 		itree, err = tree.GetImmutable(version)
 		require.NoError(t, err, "loading version %v", version)

--- a/tree_test.go
+++ b/tree_test.go
@@ -77,7 +77,7 @@ func TestVersionedRandomTree(t *testing.T) {
 	// db than in the current tree version.
 	nodes, err := tree.ndb.nodes()
 	require.Nil(err)
-	require.True(len(nodes) >= tree.nodeSize())
+	require.True(len(nodes) >= tree.ImmutableTree().nodeSize())
 
 	// Ensure it returns all versions in sorted order
 	available := tree.AvailableVersions()
@@ -92,7 +92,7 @@ func TestVersionedRandomTree(t *testing.T) {
 	require.Len(tree.versions, 1, "tree must have one version left")
 	tr, err := tree.GetImmutable(int64(versions))
 	require.NoError(err, "GetImmutable should not error for version %d", versions)
-	require.Equal(tr.root, tree.root)
+	require.Equal(tr.root, tree.ImmutableTree().root)
 
 	// we should only have one available version now
 	available = tree.AvailableVersions()
@@ -103,11 +103,11 @@ func TestVersionedRandomTree(t *testing.T) {
 	// in the db as in the current tree version.
 	leafNodes, err = tree.ndb.leafNodes()
 	require.Nil(err)
-	require.Len(leafNodes, int(tree.Size()))
+	require.Len(leafNodes, int(tree.ImmutableTree().Size()))
 
 	nodes, err = tree.ndb.nodes()
 	require.Nil(err)
-	require.Equal(tree.nodeSize(), len(nodes))
+	require.Equal(tree.ImmutableTree().nodeSize(), len(nodes))
 }
 
 // nolint: dupl
@@ -216,9 +216,9 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 	nodes, err := tree.ndb.nodes()
 	require.Nil(err)
 
-	require.Len(leafNodes, int(tree.Size()))
-	require.Len(nodes, tree.nodeSize())
-	require.Len(nodes, singleVersionTree.nodeSize())
+	require.Len(leafNodes, int(tree.ImmutableTree().Size()))
+	require.Len(nodes, tree.ImmutableTree().nodeSize())
+	require.Len(nodes, singleVersionTree.ImmutableTree().nodeSize())
 
 	// Try getting random keys.
 	for i := 0; i < keysPerVersion; i++ {
@@ -266,9 +266,9 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 	nodes, err := tree.ndb.nodes()
 	require.Nil(err)
 
-	require.Len(leafNodes, int(tree.Size()))
-	require.Len(nodes, tree.nodeSize())
-	require.Len(nodes, singleVersionTree.nodeSize())
+	require.Len(leafNodes, int(tree.ImmutableTree().Size()))
+	require.Len(nodes, tree.ImmutableTree().nodeSize())
+	require.Len(nodes, singleVersionTree.ImmutableTree().nodeSize())
 
 	// Try getting random keys.
 	for i := 0; i < keysPerVersion; i++ {
@@ -301,7 +301,7 @@ func TestVersionedTreeSpecial1(t *testing.T) {
 
 	nodes, err := tree.ndb.nodes()
 	require.Nil(t, err)
-	require.Equal(t, tree.nodeSize(), len(nodes))
+	require.Equal(t, tree.ImmutableTree().nodeSize(), len(nodes))
 }
 
 func TestVersionedRandomTreeSpecial2(t *testing.T) {
@@ -321,7 +321,7 @@ func TestVersionedRandomTreeSpecial2(t *testing.T) {
 
 	nodes, err := tree.ndb.nodes()
 	require.NoError(err)
-	require.Len(nodes, tree.nodeSize())
+	require.Len(nodes, tree.ImmutableTree().nodeSize())
 }
 
 func TestVersionedEmptyTree(t *testing.T) {
@@ -364,7 +364,7 @@ func TestVersionedEmptyTree(t *testing.T) {
 	require.False(tree.VersionExists(3))
 
 	tree.Set([]byte("k"), []byte("v"))
-	require.EqualValues(5, tree.root.version)
+	require.EqualValues(5, tree.ImmutableTree().root.version)
 
 	// Now reload the tree.
 
@@ -393,7 +393,7 @@ func TestVersionedTree(t *testing.T) {
 	// We start with empty database.
 	require.Equal(0, tree.ndb.size())
 	require.True(tree.IsEmpty())
-	require.False(tree.IsFastCacheEnabled())
+	require.False(tree.ImmutableTree().IsFastCacheEnabled())
 
 	// version 0
 
@@ -656,7 +656,7 @@ func TestVersionedTreeVersionDeletingEfficiency(t *testing.T) {
 	tree2.Set([]byte("key3"), []byte("val1"))
 	tree2.SaveVersion()
 
-	require.Equal(t, tree2.nodeSize(), tree.nodeSize())
+	require.Equal(t, tree2.ImmutableTree().nodeSize(), tree.ImmutableTree().nodeSize())
 }
 
 func TestVersionedTreeOrphanDeleting(t *testing.T) {
@@ -787,7 +787,7 @@ func TestVersionedTreeSpecialCase3(t *testing.T) {
 
 	nodes, err := tree.ndb.nodes()
 	require.NoError(err)
-	require.Equal(tree.nodeSize(), len(nodes))
+	require.Equal(tree.ImmutableTree().nodeSize(), len(nodes))
 }
 
 func TestVersionedTreeSaveAndLoad(t *testing.T) {
@@ -841,10 +841,10 @@ func TestVersionedTreeSaveAndLoad(t *testing.T) {
 	ntree.DeleteVersion(3)
 
 	require.False(ntree.IsEmpty())
-	require.Equal(int64(4), ntree.Size())
+	require.Equal(int64(4), ntree.ImmutableTree().Size())
 	nodes, err := tree.ndb.nodes()
 	require.NoError(err)
-	require.Len(nodes, ntree.nodeSize())
+	require.Len(nodes, ntree.ImmutableTree().nodeSize())
 }
 
 func TestVersionedTreeErrors(t *testing.T) {
@@ -1172,7 +1172,7 @@ func TestVersionedTreeEfficiency(t *testing.T) {
 			require.InDelta(change, keysAddedPerVersion[i], float64(keysPerVersion)/5)
 		}
 	}
-	require.Equal(keysAdded-tree.nodeSize(), keysDeleted)
+	require.Equal(keysAdded-tree.ImmutableTree().nodeSize(), keysDeleted)
 }
 
 func TestVersionedTreeProofs(t *testing.T) {
@@ -1360,7 +1360,7 @@ func TestRollback(t *testing.T) {
 
 	tree.SaveVersion()
 
-	require.Equal(int64(2), tree.Size())
+	require.Equal(int64(2), tree.ImmutableTree().Size())
 
 	val, err := tree.Get([]byte("r"))
 	require.Nil(val)
@@ -1904,13 +1904,13 @@ func Benchmark_GetWithIndex(b *testing.B) {
 	runtime.GC()
 
 	b.Run("fast", func(sub *testing.B) {
-		isFastCacheEnabled, err := t.IsFastCacheEnabled()
+		isFastCacheEnabled, err := t.ImmutableTree().IsFastCacheEnabled()
 		require.NoError(b, err)
 		require.True(b, isFastCacheEnabled)
 		b.ResetTimer()
 		for i := 0; i < sub.N; i++ {
 			randKey := rand.Intn(numKeyVals)
-			t.GetWithIndex(keys[randKey])
+			t.ImmutableTree().GetWithIndex(keys[randKey])
 		}
 	})
 
@@ -1953,13 +1953,13 @@ func Benchmark_GetByIndex(b *testing.B) {
 	runtime.GC()
 
 	b.Run("fast", func(sub *testing.B) {
-		isFastCacheEnabled, err := t.IsFastCacheEnabled()
+		isFastCacheEnabled, err := t.ImmutableTree().IsFastCacheEnabled()
 		require.NoError(b, err)
 		require.True(b, isFastCacheEnabled)
 		b.ResetTimer()
 		for i := 0; i < sub.N; i++ {
 			randIdx := rand.Intn(numKeyVals)
-			t.GetByIndex(int64(randIdx))
+			t.ImmutableTree().GetByIndex(int64(randIdx))
 		}
 	})
 


### PR DESCRIPTION
## Describe your changes and provide context
The implicit `ImmutableTree` field of a `MutableTree` might be modified, which is not currently safeguarded by any mutex. This PR fixes that by making the implicit field explicit.

## Testing performed to validate your change
existing tests

