### PR TITLE
Add a script to dump the top N contracts

### DIFF
--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -22,7 +22,7 @@ const (
 func main() {
 	args := os.Args[1:]
 	if len(args) < 3 || (args[0] != "data" && args[0] != "keys" && args[0] != "shape" && args[0] != "versions" && args[0] != "size") {
-		fmt.Fprintln(os.Stderr, "Usage: iaviewer <data|shape|versions|size> <leveldb dir> <prefix> [version number]")
+		fmt.Fprintln(os.Stderr, "Usage: iaviewer <data|keys|shape|versions|size> <leveldb dir> <prefix> [version number]")
 		fmt.Fprintln(os.Stderr, "<prefix> is the prefix of db, and the iavl tree of different modules in cosmos-sdk uses ")
 		fmt.Fprintln(os.Stderr, "different <prefix> to identify, just like \"s/k:gov/\" represents the prefix of gov module")
 		os.Exit(1)

--- a/scripts/dump_top_contracts.sh
+++ b/scripts/dump_top_contracts.sh
@@ -1,0 +1,20 @@
+#/bin/bash
+
+TOP_N=$1
+TOP_N=${TOP_N:-10}
+
+systemctl stop seid
+echo "Dumping all wasm keys to ~/wasm_keys_dump.txt..."
+iaviewer keys ~/.sei/data/application.db "s/k:wasm/" > ~/wasm_keys_dump.txt
+
+systemctl start seid
+echo "Generating top contracts to ~/top_contracts.txt..."
+cat ~/wasm_keys_dump.txt |grep "^03" |cut -c 3-66 |sort |uniq -c |sort -nr |head -n "$TOP_N" > ~/top_contracts.txt
+
+while IFS= read -r line; do
+  count=$(echo "$line" | awk '{print $1}')
+  contract_hex=$(echo "$line" | awk '{print $2}')
+  contract_address=$(seid keys parse "$contract_hex" --output json |jq -r .formats[0])
+  contract_label=$(seid query wasm contract "$contract_address" --output json |jq -r .contract_info.label)
+  echo "$contract_address - $contract_label: $count"
+done < ~/top_contracts.txt


### PR DESCRIPTION
## Describe your changes and provide context
1. Added a new command for iavlViewer to only print keys
2. Minor bug fixes
3. Added a script to dump top N contracts
## Testing performed to validate your change
Tested on atlantic-2 and pacific-1 rpc node
