### PR TITLE
Fix nil interface conversion error

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -104,7 +104,11 @@ func (c *lruCache) Remove(key []byte) Node {
 }
 
 func (c *lruCache) remove(e *list.Element) Node {
-	removed := c.ll.Remove(e).(Node)
-	delete(c.dict, ibytes.UnsafeBytesToStr(removed.GetCacheKey()))
-	return removed
+	element := c.ll.Remove(e)
+	if element != nil {
+		node := element.(Node)
+		delete(c.dict, ibytes.UnsafeBytesToStr(node.GetCacheKey()))
+		return node
+	}
+	return nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
This patch fix an edge case where the to be removed node doesn't exist, the interface conversion will fail with nil errors.

## Testing performed to validate your change
Fixed this error:
```

Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: panic: interface conversion: interface is nil, not cache.Node
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: goroutine 2164 [running]:
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/iavl/cache.(*lruCache).remove(0xc00075df20, 0xc00064d080?)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.8/cache/cache.go:107 +0xb0
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/iavl/cache.(*lruCache).Add(0xc00075df20, {0x2d5e860, 0xc01c6762d0})
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-iavl@v0.1.8/cache/cache.go:77 +0x31b
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/sei-protocol/sei-db/sc/memiavl.(*Tree).addToCache(0xc00029f8b0, {0xc015e78f48, 0x16, 0x18}, {0xc00e648820, 0x184, 0x1a0})
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-db@v0.0.24/sc/memiavl/tree.go:309 +0x125
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/sei-protocol/sei-db/sc/memiavl.(*Tree).Get(0x213b780?, {0xc015e78f48, 0x16, 0x18})
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-db@v0.0.24/sc/memiavl/tree.go:225 +0x8e
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/storev2/commitment.(*Store).Get(0xc017035620?, {0xc015e78f48?, 0xc00905c400?, 0x1?})
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/storev2/commitment/store.go:97 +0x26
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/store/cachekv.(*Store).getFromCache(0xc0208e9110, {0xc015e78f48, 0x16, 0x18})
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/store/cachekv/store.go:72 +0x98
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/store/cachekv.(*Store).Get(0xc017035b90?, {0xc015e78f48?, 0x235083a?, 0x18?})
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/store/cachekv/store.go:78 +0x25
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/store/gaskv.(*Store).Get(0xc0189e2660, {0xc015e78f48, 0x16, 0x18})
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/store/gaskv/store.go:43 +0x71
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/x/staking/keeper.Keeper.GetValidator({{0x2d65868, 0xc0001deb00}, {0x2d8f040, 0xc0004e4330}, {0x2d82fe0, 0xc0004cda40}, {0x7fedd3e92c98, 0xc000325520}, {0x2d8ea18, 0xc00075ccf0}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/x/staking/keeper/validator.go:17 +0x10a
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/x/staking/keeper.Keeper.mustGetValidator({{0x2d65868, 0xc0001deb00}, {0x2d8f040, 0xc0004e4330}, {0x2d82fe0, 0xc0004cda40}, {0x7fedd3e92c98, 0xc000325520}, {0x2d8ea18, 0xc00075ccf0}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/x/staking/keeper/validator.go:27 +0xe5
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/x/staking/keeper.Keeper.ApplyAndReturnValidatorSetUpdates({{0x2d65868, 0xc0001deb00}, {0x2d8f040, 0xc0004e4330}, {0x2d82fe0, 0xc0004cda40}, {0x7fedd3e92c98, 0xc000325520}, {0x2d8ea18, 0xc00075ccf0}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/x/staking/keeper/val_state_change.go:131 +0x4b8
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/x/staking/keeper.Keeper.BlockValidatorUpdates({{0x2d65868, 0xc0001deb00}, {0x2d8f040, 0xc0004e4330}, {0x2d82fe0, 0xc0004cda40}, {0x7fedd3e92c98, 0xc000325520}, {0x2d8ea18, 0xc00075ccf0}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/x/staking/keeper/val_state_change.go:27 +0x7b
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/x/staking.EndBlocker({{0x2d7e7d8, 0xc012bbaae0}, {0x2d95358, 0xc0105b9a80}, {{0x0, 0x0}, {0x7ffe034eeed5, 0xa}, 0x37df884, {0x11268b7c, ...}, ...}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/x/staking/abci.go:25 +0xfb
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/x/staking.AppModule.EndBlock(...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/x/staking/module.go:174
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/types/module.(*Manager).EndBlock(_, {{0x2d7e7d8, 0xc012bbaae0}, {0x2d95358, 0xc0105b9a80}, {{0x0, 0x0}, {0x7ffe034eeed5, 0xa}, 0x37df884, ...}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/types/module/module.go:550 +0x390
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/sei-protocol/sei-chain/app.(*App).EndBlocker(_, {{0x2d7e7d8, 0xc012bbaae0}, {0x2d95358, 0xc0105b9a80}, {{0x0, 0x0}, {0x7ffe034eeed5, 0xa}, 0x37df884, ...}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /home/ubuntu/sei-chain/app/app.go:944 +0x79
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).EndBlock(_, {{0x2d7e7d8, 0xc012bbaae0}, {0x2d95358, 0xc0105b9a80}, {{0x0, 0x0}, {0x7ffe034eeed5, 0xa}, 0x37df884, ...}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/baseapp/abci.go:183 +0x149
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/sei-protocol/sei-chain/app.(*App).EndBlock(_, {{0x2d7e7d8, 0xc012bbaae0}, {0x2d95358, 0xc0105b9a80}, {{0x0, 0x0}, {0x7ffe034eeed5, 0xa}, 0x37df884, ...}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /home/ubuntu/sei-chain/app/abci.go:32 +0x145
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/sei-protocol/sei-chain/app.(*App).ProcessBlock(_, {{0x2d7e7d8, 0xc012bbaae0}, {0x2d95358, 0xc0105b9a80}, {{0x0, 0x0}, {0x7ffe034eeed5, 0xa}, 0x37df884, ...}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /home/ubuntu/sei-chain/app/app.go:1365 +0xb65
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/sei-protocol/sei-chain/app.(*App).FinalizeBlocker(_, {{0x2d7e7d8, 0xc012bbaab0}, {0x2d95358, 0xc0105b9a80}, {{0x0, 0x0}, {0x7ffe034eeed5, 0xa}, 0x37df884, ...}, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /home/ubuntu/sei-chain/app/app.go:1035 +0x335
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).FinalizeBlock(0xc0001c8780, {0x2d7e730?, 0xc0004ca4c0?}, 0xc02446cb60)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-cosmos@v0.2.69/baseapp/abci.go:1081 +0x785
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/tendermint/tendermint/internal/proxy.(*proxyClient).FinalizeBlock(0xc000472620, {0x2d7e730, 0xc0004ca4c0}, 0x11?)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.35/internal/proxy/client.go:154 +0x102
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/tendermint/tendermint/internal/state.(*BlockExecutor).ApplyBlock(_, {_, _}, {{{0xb, 0x0}, {0xc00872ef90, 0x11}}, {0xc00a32cbe0, 0xa}, 0x1, ...}, ...)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.35/internal/state/execution.go:249 +0x987
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: github.com/tendermint/tendermint/internal/blocksync.(*Reactor).poolRoutine(0xc0042222c0, {0x2d7e730?, 0xc0004ca4c0}, 0x0, 0xc00a069fb0?)
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.35/internal/blocksync/reactor.go:698 +0x1595
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]: created by github.com/tendermint/tendermint/internal/blocksync.(*Reactor).OnStart
Jan 02 20:57:16 ip-172-31-24-248 seid[28083]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.35/internal/blocksync/reactor.go:181 +0x64a
```